### PR TITLE
Add Rust desktop app toolkit docs

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,18 @@
+# AGENTS Guide for `docs`
+
+This directory contains documentation for building Rust-based native desktop applications, inspired by the Zed codebase. The goal is to provide a toolkit for quickly bootstrapping new desktop apps using the patterns and packages found here.
+
+## Overview
+- **Purpose**: Serve as a reference for developers looking to create high-performance desktop apps in Rust.
+- **Scope**: Covers architecture, package organization, AI integrations, and design system usage based on Zed's implementation.
+- **Audience**: Rust developers familiar with the language but new to large-scale desktop development.
+
+## Development Workflow
+- Build documentation locally with `mdbook serve docs` (requires `mdbook`).
+- Keep examples minimal and cross-platform.
+
+## Contribution Guidelines
+- Update or add docs incrementally.
+- Reference relevant code paths when possible to keep documentation verifiable.
+- No tests or linting are required for doc changes unless specifically requested.
+

--- a/docs/desktop-app-toolkit/README.md
+++ b/docs/desktop-app-toolkit/README.md
@@ -1,0 +1,10 @@
+# Rust Desktop App Toolkit
+
+This toolkit distills lessons from the Zed codebase for building cross-platform desktop applications in Rust.
+
+- **Architecture** – Overview of the crate-based workspace approach.
+- **Design System** – Using the [`gpui`](../crates/gpui) framework to render UI.
+- **AI Integration** – Leveraging crates like [`open_ai`](../../crates/open_ai) for LLM features.
+- **Packaging** – Scripts and settings for delivering apps on macOS, Linux, and Windows.
+
+Each topic has a dedicated markdown file in this directory.

--- a/docs/desktop-app-toolkit/ai-integration.md
+++ b/docs/desktop-app-toolkit/ai-integration.md
@@ -1,0 +1,13 @@
+# AI Integration
+
+Zed integrates large language models through crates like [`open_ai`](../../crates/open_ai).
+The crate defines request structures and helpers to communicate with the OpenAI API:
+
+```rust
+pub const OPEN_AI_API_URL: &str = "https://api.openai.com/v1";
+```
+
+Models are enumerated and provide metadata like maximum token counts.
+See [`open_ai.rs`](../../crates/open_ai/src/open_ai.rs) for full details.
+
+When building your own app, create a client module that wraps these APIs and expose them via async functions.

--- a/docs/desktop-app-toolkit/architecture.md
+++ b/docs/desktop-app-toolkit/architecture.md
@@ -1,0 +1,20 @@
+# Architecture
+
+Zed organizes its code as a Cargo workspace with many crates.
+A similar approach scales well for desktop apps:
+
+1. **Workspace** – define shared dependencies in `Cargo.toml` at the root.
+2. **Crates** – split features into crates under `crates/`.
+3. **Binary targets** – build launchers like `cli` and `zed`.
+
+The root `Cargo.toml` lists dozens of crates that compose the editor, as seen here:
+```toml
+# excerpt
+members = [
+    "crates/activity_indicator",
+    "crates/agent",
+    ...
+]
+```
+
+Leveraging a workspace keeps packages independent while enabling cross-crate development.

--- a/docs/desktop-app-toolkit/building.md
+++ b/docs/desktop-app-toolkit/building.md
@@ -1,0 +1,17 @@
+# Building & Packaging
+
+Zed provides scripts for each platform in `docs/src/development`.
+The basic workflow on macOS is:
+
+```bash
+cargo run
+```
+
+Release builds use `cargo run --release`.
+For backend services (collaboration, AI), dependencies can be started with:
+
+```bash
+docker compose up -d
+```
+
+Similar instructions exist for Linux and Windows. Consult the [`macos.md`](../../docs/src/development/macos.md) and other platform docs for troubleshooting tips.

--- a/docs/desktop-app-toolkit/design-system.md
+++ b/docs/desktop-app-toolkit/design-system.md
@@ -1,0 +1,13 @@
+# Design System
+
+Zed's UI is powered by the [`gpui`](../../crates/gpui) crate. It blends immediate
+and retained rendering paradigms.
+
+Key ideas from [`gpui`'s README](../../crates/gpui/README.md):
+
+- State is stored in `Entity` objects managed by GPUI.
+- Views implement the `Render` trait and build trees of elements using a
+  Tailwind-like API.
+- Elements provide low-level control for custom layouts.
+
+These patterns enable fluid, GPU-accelerated interfaces.

--- a/docs/desktop-app-toolkit/packages.md
+++ b/docs/desktop-app-toolkit/packages.md
@@ -1,0 +1,10 @@
+# Packages & Modules
+
+Zed splits functionality into many crates under `crates/`. When creating your own workspace, consider separating concerns similarly:
+
+- `core` – shared types and utilities
+- `ui` – views and the gpui-based design system
+- `services` – async tasks like networking or database access
+- `cli` – command-line interface for launching the app
+
+The `[workspace]` section of `Cargo.toml` enumerates all members. Using features and crate boundaries keeps builds fast and improves modularity.


### PR DESCRIPTION
## Summary
- add `docs/AGENTS.md` describing how to extend docs for Rust desktop app development
- introduce `docs/desktop-app-toolkit/` with notes on architecture, design, AI integration and building

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683c7cb338808333b9ba188a2afa0881