### PR TITLE
Refine Saya UI for button-based scenes

### DIFF
--- a/assets/prompts/saya_scene_prompt.hbs
+++ b/assets/prompts/saya_scene_prompt.hbs
@@ -1,0 +1,18 @@
+<prompt>
+  <instructions>
+    You are the narrator of a fantasy adventure game rendered entirely in ASCII.
+    Describe the surroundings in vivid detail and include a small block of ASCII art.
+    Present exactly four numbered options the player can take next.
+    Wrap the entire response in <scene> tags as shown below.
+  </instructions>
+  <scene>
+    <ascii>{{{ascii_art}}}</ascii>
+    <description>{{{description}}}</description>
+    <options>
+      <option number="1">{{option_1}}</option>
+      <option number="2">{{option_2}}</option>
+      <option number="3">{{option_3}}</option>
+      <option number="4">{{option_4}}</option>
+    </options>
+  </scene>
+</prompt>

--- a/crates/saya/Cargo.toml
+++ b/crates/saya/Cargo.toml
@@ -16,4 +16,6 @@ path = "src/main.rs"
 gpui.workspace = true
 gpui_tokio.workspace = true
 open_ai.workspace = true
+assets.workspace = true
+ui.workspace = true
 workspace-hack.workspace = true

--- a/crates/saya/src/main.rs
+++ b/crates/saya/src/main.rs
@@ -1,25 +1,48 @@
+use assets::Assets;
 use gpui::{App, Application, Bounds, Context, Window, WindowBounds, WindowOptions, prelude::*, px, size};
+use ui::prelude::*;
+struct SayaApp;
 
-struct Game;
-
-impl Render for Game {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        pre(
-"Saya\n\n1. Explore the forest\n2. Check inventory\n3. Rest at camp"
+impl Render for SayaApp {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let viewport = pre(
+            "~ Saya ~\n\n1. Explore the forest\n2. Check inventory\n3. Rest at camp",
         )
+        .font_family("Zed Mono")
         .p_4()
         .text_color(gpui::white())
         .bg(gpui::black())
+        .flex_grow();
+
+        let buttons = ["1", "2", "3", "4"].iter().enumerate().map(|(i, label)| {
+            Button::new(format!("option_{i}", i = i + 1), *label)
+        });
+
+        v_flex()
+            .size_full()
+            .font_family("Zed Mono")
+            .gap_2()
+            .children(vec![
+                viewport.into_any_element(),
+                h_flex()
+                    .gap_2()
+                    .children(buttons.map(|b| b.into_any_element()).collect())
+                    .into_any_element(),
+            ])
     }
 }
 
 fn main() {
-    Application::new().run(|cx: &mut App| {
-        let bounds = Bounds::centered(None, size(px(600.0), px(400.0)), cx);
-        cx.open_window(
-            WindowOptions { window_bounds: Some(WindowBounds::Windowed(bounds)), ..Default::default() },
-            |_, cx| cx.new(|_| Game),
-        ).unwrap();
-        cx.activate(true);
-    });
+    Application::new()
+        .with_assets(Assets)
+        .run(|cx: &mut App| {
+            Assets.load_fonts(cx).unwrap();
+
+            let bounds = Bounds::centered(None, size(px(600.0), px(500.0)), cx);
+            cx.open_window(
+                WindowOptions { window_bounds: Some(WindowBounds::Windowed(bounds)), ..Default::default() },
+                |_, cx| cx.new(|_| SayaApp),
+            ).unwrap();
+            cx.activate(true);
+        });
 }

--- a/docs/desktop-app-toolkit/design-system.md
+++ b/docs/desktop-app-toolkit/design-system.md
@@ -11,3 +11,28 @@ Key ideas from [`gpui`'s README](../../crates/gpui/README.md):
 - Elements provide low-level control for custom layouts.
 
 These patterns enable fluid, GPU-accelerated interfaces.
+
+## Custom ASCII Style
+
+`gpui` is flexible enough to drive other design languages. The `saya` example
+registers the bundled fonts using `assets::Assets` and then applies a monospace
+font to the entire view:
+
+```rust
+use assets::Assets;
+use ui::prelude::*;
+
+Application::new()
+    .with_assets(Assets)
+    .run(|cx| {
+        Assets.load_fonts(cx).unwrap();
+        cx.open_window(WindowOptions::default(), |_, cx| {
+            cx.new(|_| SayaApp)
+        }).unwrap();
+    });
+```
+
+Inside the `Render` implementation the root container sets the font family to
+`Zed Mono` and arranges the viewport and buttons using `v_flex` and `h_flex`
+helpers. This produces an old terminal look and serves as a starting point for
+building a full ASCII design system.

--- a/docs/desktop-app-toolkit/saya.md
+++ b/docs/desktop-app-toolkit/saya.md
@@ -18,6 +18,19 @@ This example project demonstrates building a lightweight desktop game named **Sa
 +-------------------------------+
 ```
 
+## Updated Layout
+
+The interface focuses on a viewport that renders ASCII art from the AI. Below
+the viewport are four buttons representing the actions the player can take.
+
+```text
++-----------------------------------+
+| ~ scene text here ~               |
+|                                   |
+| [1] [2] [3] [4]                   |
++-----------------------------------+
+```
+
 ## Prompt Template
 
 ```text


### PR DESCRIPTION
## Summary
- drop the text input from the Saya example
- simplify the window creation API call in the docs
- explain that each scene only uses buttons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683da9e82c8c8333a930a969b23c41e5